### PR TITLE
doc/built-in-helpers

### DIFF
--- a/template-syntax/built-in-helpers.md
+++ b/template-syntax/built-in-helpers.md
@@ -7,7 +7,7 @@ description: A list of all Squirrelly's built-in native helpers..
 ## if/else
 
 ```text
-{{if(options.somevalue === 1)}}
+{{@if(options.somevalue === 1)}}
 Display this
 {{#else}}
 Display this


### PR DESCRIPTION
i followed this example and found the `@`-prefix was missing. It may be missing from other places.